### PR TITLE
Add device to test_rope_rotate

### DIFF
--- a/tests/unittests/test_attention.py
+++ b/tests/unittests/test_attention.py
@@ -139,6 +139,7 @@ def rope_rotate_slow(x: np.ndarray):
     ],
 )
 def test_rope_rotate(
+    device,
     numpy_dtype,
     torch_dtype,
     tolerance,
@@ -157,7 +158,7 @@ def test_rope_rotate(
         -1, +1, (batch_size, length, num_heads, num_dimensions)
     ).astype(numpy_dtype)
 
-    result = _rope_rotate(torch.tensor(x, dtype=torch_dtype))
+    result = _rope_rotate(torch.tensor(x, dtype=torch_dtype, device=device))
     assert result.dtype == torch_dtype
     result_np = result.cpu().numpy()
 


### PR DESCRIPTION
This runs `test_rope_rotate` on the device passed in on the command line. (And, testing it locally, it seems to work with `--device=cuda`.)